### PR TITLE
submit nested SeriesMarkerBas<H>[] to jsmodule.InvokeVoidAsync Method

### DIFF
--- a/src/LightweightCharts.Blazor/Plugins/SeriesMarkersPluginApi.cs
+++ b/src/LightweightCharts.Blazor/Plugins/SeriesMarkersPluginApi.cs
@@ -46,7 +46,7 @@ namespace LightweightCharts.Blazor.Plugins
 		public ValueTask SetMarkers(SeriesMarkerBase<H>[] markers)
 		{
 			_Markers = markers ?? [];
-			return JsModule.InvokeVoidAsync(JsRuntime, JsObjectReference, "setMarkers", false, _Markers);
+			return JsModule.InvokeVoidAsync(JsRuntime, JsObjectReference, "setMarkers", false, [_Markers]);
 		}
 
 		public SeriesMarkerBase<H>[] Markers()


### PR DESCRIPTION
Fix how series markers are supplied to the LightweightCharts SetMarkers method so that the method works as expected.