### PR TITLE
Migrate to .Net 10

### DIFF
--- a/src/LightweightCharts.Blazor/Customization/Chart/SolidColor.cs
+++ b/src/LightweightCharts.Blazor/Customization/Chart/SolidColor.cs
@@ -14,7 +14,8 @@ namespace LightweightCharts.Blazor.Customization.Chart
 		/// <summary>
 		/// <inheritdoc/>
 		/// </summary>
-		public override ColorType Type
+		[JsonIgnore]
+        public override ColorType Type
 			=> ColorType.Solid;
 
 		/// <summary>

--- a/src/LightweightCharts.Blazor/Customization/Chart/VerticalGradientColor.cs
+++ b/src/LightweightCharts.Blazor/Customization/Chart/VerticalGradientColor.cs
@@ -14,6 +14,7 @@ namespace LightweightCharts.Blazor.Customization.Chart
 		/// <summary>
 		/// <inheritdoc/>
 		/// </summary>
+		[JsonIgnore]
 		public override ColorType Type
 			=> ColorType.VerticalGradient;
 

--- a/src/LightweightCharts.Blazor/LightweightCharts.Blazor.csproj
+++ b/src/LightweightCharts.Blazor/LightweightCharts.Blazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>LightweightCharts.Blazor</PackageId>
 		<PackageVersion>5.0.8.1</PackageVersion>
@@ -37,7 +37,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.19" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
With .net 10, System.Text.Json enforces validation of reserved keywords (such as "type") when using polymorphic interfaces, so added an "Ignore" attribute to serialised getter only properties that violate the validation and caused runtime errors.